### PR TITLE
Spelling fixes for Nord and Bert Couldn't Make Head or Tail of It

### DIFF
--- a/aisle.zil
+++ b/aisle.zil
@@ -515,7 +515,7 @@ but now they're a blight on the store." CR>)>)
 <ROUTINE BRITISH-ROOM-F (RARG)
 	 <COND (<EQUAL? .RARG ,M-LOOK>
 		<TELL
-"The floor here is richly painted in the bold colours of Brittania.">)>> 
+"The floor here is richly painted in the bold colours of Britannia.">)>> 
 
 <OBJECT BRITISH-SHELF
 	(LOC BRITISH-ROOM)

--- a/aisle.zil
+++ b/aisle.zil
@@ -430,7 +430,7 @@ passed their expiration date. They may have been once used as bait-and-switch,
 but now they're a blight on the store." CR>)>)
 	       ;"muscles"
 	       (<VERB? EAT>
-		<TELL "Auto-canibalism is not the answer." CR>)>>
+		<TELL "Auto-cannibalism is not the answer." CR>)>>
 
 <OBJECT SAIL
 	(LOC MUSSEL-SHELF)

--- a/dueling.zil
+++ b/dueling.zil
@@ -379,7 +379,7 @@ of paint lingers in the air.">)>>
 	 <COND (<VERB? EXAMINE>
 		<TELL
 "The television set, which has been left droning on here, is now showing
-a marathon of laundry detergent comercials." CR>)
+a marathon of laundry detergent commercials." CR>)
 	       (<VERB? OFF SET>
 		<TELL "It has no controls of any kind." CR>)>>    
 		

--- a/dueling.zil
+++ b/dueling.zil
@@ -600,7 +600,7 @@ capitalist booty!" CR>)>>
 	(DESC "safe")
 	(LDESC 
 "A safe has been revealed high on the wall where the portrait of the
-Father of our Revolution has once proundly hung.")
+Father of our Revolution has once proudly hung.")
 	(SYNONYM SAFE LOCK)
 	(ADJECTIVE UNIVERSIAL)
 	(FLAGS NDESCBIT CONTBIT SEARCHBIT LOCKEDBIT)

--- a/eight.zil
+++ b/eight.zil
@@ -823,7 +823,7 @@ deal with you">)>)
 regard you as a minor player in a lower league politically than himself">)
 			     (<NOT <FSET? ,BLESSING ,PHRASEBIT>>
 			      <TELL
-"The mayor, pacing the floor and appearing cursed by the disasterous plague of
+"The mayor, pacing the floor and appearing cursed by the disastrous plague of
 nonsense that has beset his town, ignores the decree">)
 			     (<NOT <FSET? ,LINEN ,PHRASEBIT>>
 			      <TELL

--- a/farm.zil
+++ b/farm.zil
@@ -139,7 +139,7 @@ legs.">)
       (LOC ROOMS)
       (DESC "Road")
       (LDESC 
-"The telltail smell of grain and dung drifts by. You're on a dusty
+"The telltale smell of grain and dung drifts by. You're on a dusty
 road in front of abandoned farm -- a nice-sized spread of land that
 stretches far out to meet the horizon.")
       (GLOBAL FARM)

--- a/farm.zil
+++ b/farm.zil
@@ -1110,7 +1110,7 @@ a needle there">)>
 		      <TELL
 "What on earth do you expect to find in a haystack?" CR>)
 		      (T
-		       <TELL "You arleady have." CR>)>)
+		       <TELL "You already have." CR>)>)
 	       (<VERB? CLIMB-UP CLIMB CLIMB-ON ENTER BOARD>
 		<TELL 
 "You step up the pungent haystack, and slide back down." CR>) 

--- a/farm.zil
+++ b/farm.zil
@@ -1100,7 +1100,7 @@ yellow stalks of hay grass. You grab it">)
 			      <RTRUE>)>)
 		      (T
 		       <TELL 
-"Finding" A ,PRSI " in a haystack is even less likey than finding
+"Finding" A ,PRSI " in a haystack is even less likely than finding
 a needle there">)>
 		<TELL ,PERIOD>)
 	       (<VERB? SEARCH>

--- a/farm.zil
+++ b/farm.zil
@@ -1243,7 +1243,7 @@ each other's heavenward flight path.|
 You take aim and throw, and the birds explode in rapid succession like clay
 pigeons.|
 |
-The old dog lets out a long, wolfish howl which echoes thoughout the
+The old dog lets out a long, wolfish howl which echoes throughout the
 valley." CR>)
 	       (<VERB? KILL>
 		<COND (,PRSI

--- a/globals.zil
+++ b/globals.zil
@@ -1009,7 +1009,7 @@ well within the realm of possibilities." CR CR>
 			      <QUEUE I-DEAN -1>)>
 		       <SETG HINT-TBL ,HAZING-HINTS>
 		       <TELL
-"In the dark forest outside the town boundries of Punster, chaos has been
+"In the dark forest outside the town boundaries of Punster, chaos has been
 the order of the day. On a recent afternoon the daughter of a leading citizen
 of our town, out for a stroll among the tall pines, disappeared without
 apparent trace. Rumor has it that one strange, stand-alone door is the only

--- a/globals.zil
+++ b/globals.zil
@@ -996,7 +996,7 @@ family farm." CR CR>
 		       <COND (<FINISHED? ,JOAT>
 			      <RTRUE>)>
 		       <TELL 
-"The oddities of language have been so prevalant in the town of Punster,
+"The oddities of language have been so prevalent in the town of Punster,
 that surrounding communities have been similarly affected. One such bordering
 town is Jackville, located in the northern backwoods region, but still
 well within the realm of possibilities." CR CR>

--- a/globals.zil
+++ b/globals.zil
@@ -986,7 +986,7 @@ Act the Part, Visit the Manor of Speaking, or Shake a Tower."
 "The farm crisis never seemed so desperate as it has this planting season
 in Punster. One such family farm on the edge of town, the McCleary's, has
 been especially blighted. The family, though well accustomed to hard work,
-suddenly lost the ability to perform even the simplist of chores necessary to
+suddenly lost the ability to perform even the simplest of chores necessary to
 scratch a living from the soil. They have since been driven from the land,
 and join with their fellow Punster neighbors in urging you to somehow save the
 family farm." CR CR>

--- a/hazing.zil
+++ b/hazing.zil
@@ -1909,7 +1909,7 @@ you actually remember hearing this noise from reruns of Hee-Haw." CR>)>)
 more than you do." CR>)
 	       (<VERB? EXAMINE>
 		<TELL 
-"The meal is perfectly square, and looks scrumptous." CR>)>>
+"The meal is perfectly square, and looks scrumptious." CR>)>>
 
 <ROOM CLOUD-ROOM
       (LOC ROOMS)

--- a/hazing.zil
+++ b/hazing.zil
@@ -219,7 +219,7 @@ chances for finding her. 'they will go to great lengths to keep her from me.'"
 	(OLDDESC "door")
 	(NEWDESC "shore")
 	(OLD-TO-NEW 
-"The wind suddenly picks fiercly, and blows blinding sand the volume
+"The wind suddenly picks fiercely, and blows blinding sand the volume
 of dunes into the area. When the wind dies down, you find your surroundings
 have changed...")
 	(DESCFCN SHINING-DOOR-F)

--- a/hazing.zil
+++ b/hazing.zil
@@ -133,7 +133,7 @@ of that existence is the stock room." CR>)>)
 			      <TELL ,DONT-KNOW-WHERE>)
 			     (<NOT <FSET? ,FACTORY ,TOUCHBIT>>
 			      <TELL  "You follow in the precise
-direction of the shepherd. It's trecherous going, since you're
+direction of the shepherd. It's treacherous going, since you're
 travelling over dill and hail -- that is, pickles strewn along the
 paths, and ice chunks hurling from the sky. You eventually come upon an
 out-of-the-way spot along the now quite polluted river. It's a prime

--- a/hazing.zil
+++ b/hazing.zil
@@ -1550,7 +1550,7 @@ shape, stands here looking disheveled and shaken">)>
 			      <RTRUE>)
 			     (<EQUAL? ,HERE ,STOCK-ROOM>
 			      <TELL
-"He's too busy rumaging through the clothes to notice you." CR>
+"He's too busy rummaging through the clothes to notice you." CR>
 			      <STOP>)
 			     (T
 			      <TELL "He ignores you." CR>

--- a/hazing.zil
+++ b/hazing.zil
@@ -1611,7 +1611,7 @@ and puts his hands on his hips." CR>)
 		<JIGS-UP
 "You get a sinking feeling as you're hammered through the floor of the cloud
 like a wooden peg. The view of the divided farmland below is picture-book
-and enobling. Your fodder enriches further the land.">)>>
+and ennobling. Your fodder enriches further the land.">)>>
 
 <ROUTINE CLIENT-FALL ()
 	 <UPDATE-SCORE>

--- a/north.zil
+++ b/north.zil
@@ -894,7 +894,7 @@ from you." CR>)>>
 		       <RTRUE>)>
 		<COND (<NOT <FSET? ,MERMAID ,RMUNGBIT>>
 		       <TELL CR
-"A mermaid swims desperately under the suface of the ice.">)
+"A mermaid swims desperately under the surface of the ice.">)
 		      (T
 		       <TELL CR 
 "A mermaid is lying exhausted on the ice.">)>)

--- a/north.zil
+++ b/north.zil
@@ -745,7 +745,7 @@ side to side below the surface of the ice." CR>)>)>>
 		       <RTRUE>)>  
 		<TELL "The ice is too thick">
 		<COND (,PRSI
-		       <TELL " to be penatrated by" T ,PRSI>)>
+		       <TELL " to be penetrated by" T ,PRSI>)>
 		<TELL ,PERIOD>)>>
 	       
 <OBJECT FROST

--- a/restaurant.zil
+++ b/restaurant.zil
@@ -424,7 +424,7 @@ the chair, sweat draining from your temples">)
 		      (<PRSO? ,ADVICE>
 		       <TELL 
 "You read the advice in a loud voice with much sarcasm, taking it so
-lightly that the slip of paper almosts drifts up into the air. The
+lightly that the slip of paper almost drifts up into the air. The
 waitress seems snubbed that you don't seem to be taking the advice to
 heart">)
 		      (<PRSO? ,UMBRAGE>

--- a/tells.zil
+++ b/tells.zil
@@ -1201,7 +1201,7 @@ who untied me so I could type out this story.]|">
 			    <EQUAL? ,WIFE-N 2>>
 		       <TELL CR 
 "She walks over to Bob and consoles him as he describes what a
-meanee you have been." CR>)
+meanie you have been." CR>)
 		      (<AND <EQUAL? ,HERE ,FRONT-ROOM>
 			    <EQUAL? ,WIFE-N 3>>
 		       <TELL CR

--- a/verbs.zil
+++ b/verbs.zil
@@ -1116,7 +1116,7 @@ flings " .STR " away over the shelves" >
 		<UPDATE-SCORE>
 		<SETG MINCE-EATEN T>
 		<TELL
-		 ". There's a noticable improvement in his breath, even from here">)>
+		 ". There's a noticeable improvement in his breath, even from here">)>
 		<TELL ,PERIOD>>
 
 <ROUTINE GIVE-TO-ROCKS ()


### PR DESCRIPTION
These are the spelling fixes for Nord and Bert Couldn't Make Head or Tail of It from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.